### PR TITLE
Add link to session video

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 Datum: 26.07.2017, 18:30<br/>
 Location: <a href="http://www.coworkingcube.at/">Coworking Cube Pucking</a><br/>
 Talk 1: Bernhard Rübl: Geschichten über Tasks (<a href="https://github.com/bernhard-ruebl/AsyncSamples">Code</a>)<br/>
-Talk 2: Rainer Stropek: Dockerizing .NET Apps<br/>
+Talk 2: Rainer Stropek: Dockerizing .NET Apps (<a href="http://www.software-architects.com/devblog/2017/07/26/dotnet-stammtisch-dockerizing-dotnet-apps">Video vom Vortrag</a>)<br/>
 </p>
 
 <h1>Frühere Termine</h1>


### PR DESCRIPTION
Add link to blog post with embedded session video (YouTube)