### PR TITLE
Small Design Improvments

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,90 +18,143 @@
     <title>.NET Stammtisch Linz</title>
 
     <!-- Bootstrap -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container-fluid">
-        <h1>.NET Stammtisch Linz</h1>
-        <p>Meetup im Linzer Raum, für Leute die an .NET Entwicklung interessiert sind. Ziel soll sein die Möglichkeit für einen Erfahrungsaustausch in Linz zu schaffen rund um Microsoft/.NET/Azure Themen. Der .NET Stammtisch ist kostenlos und jeder darf kommen. Thematisch ist alles erlaubt das irgendwie mit .NET Framework oder Microsoft Azure zu tun hat.</p>
-        <i>Eine Anmeldung auf Meetup oder Facebook hilft uns die richtigen Mengen an Verpflegung bereitstellen zu können. Danke!</i>
-        
-        <h2>.NET Stammtisch #5</h2>
-        <dl class="dl-horizontal">
-            <dt>Datum</dt><dd><p>TBD</p></dd>
-            <dt>Location</dt>
-            <dd>
-                <p><a href="https://dataformers.at/">Dataformers</a></p>
-            </dd>
-            <dt>Talk 1</dt>
-            <dd>
-                <p>TBD</p>
-            </dd>
-            <dt>Talk 2</dt>
-            <dd>
-                <p>TBD</p>
-            </dd>
-        </dl>
-        
-        <h2>Frühere Termine</h2>
-        
-        <h3>.NET Stammtisch #4 (<a href="https://www.meetup.com/NET-Stammtisch-Linz/events/247045584/">Meetup</a>, <a href="https://www.facebook.com/events/868682779976980">Facebook</a>)</h3>
-        <dl class="dl-horizontal">
-            <dt>Datum</dt><dd>20.02.2018, 18:30</dd>
-            <dt>Sponsoring</dt>
-            <dd>
-                Dieses Mal sponsern <strong>Microsoft</strong> und <strong><a href="https://www.timecockpit.com/">Time Cockpit</a></strong> die Verpflegung.
-            </dd>
-            <dt>Location</dt>
-            <dd>
-                <a href="https://factory300.spaces.nexudus.com/en/events/view//471680211/net-stammtisch-linz-4">Factory300</a> (Peter-Behrens-Platz 10, 4020 Linz)
-                <!--
-                <div class="alert alert-info">
-                    <p>Die Veranstaltung ist natürlich wie immer kostenlos. Der Veranstalter hat uns jedoch darum gebeten, trotzdem auf "Get tickets" beim verlinkten Event zu klicken. Vielen Dank!</p>
-                    <p>Folgenden Disclaimer müssen die TeilnehmerInnen akzeptieren:
-                        <br/>
-                        "Microsoft may use your email address to send you relevant content or offers. You can unsubscribe at any time. <a href="https://go.microsoft.com/fwlink/?LinkId=521839">Microsoft Privacy Statement</a>"
-                       <br/> 
-                        *Falls jemand damit ein Problem hat, bitte einfach bei uns melden!</p>
-                </div>
-                -->
+    <div class="container">
+        <!-- Header -->
+        <div class="mb-3">
+            <h1>.NET Stammtisch Linz</h1>
+            <h6>(
+                <a href="https://www.meetup.com/NET-Stammtisch-Linz/">Meetup</a>, 
+                <a href="https://www.facebook.com/groups/1487350314622729/">Facebook</a>,
+                <a href="https://twitter.com/DotNetLinz">Twitter</a>,
+                <a href="https://github.com/dotnetstammtisch/dotnetstammtisch.github.io">Github</a>
+                )
+            </h6>
+    
+            <p>
+                Meetup im Linzer Raum, für Leute die an .NET Entwicklung interessiert sind. Ziel soll sein die Möglichkeit für einen Erfahrungsaustausch 
+                in Linz zu schaffen rund um Microsoft/.NET/Azure Themen. Der .NET Stammtisch ist kostenlos und jeder darf kommen. 
+                Thematisch ist alles erlaubt das irgendwie mit .NET Framework oder Microsoft Azure zu tun hat.
+            </p>
             
-            </dd>
-            <dt>Talk 1</dt>
-            <dd>
-                <p><strong>Igor Rončević: Super-powers and the Compiler</strong></p>
-                <p>
-Try to imagine how powerful would it be if programmers could look at their code through the eyes of their compilers. If they could automatically analyze their code, improve it, change it, cover it with tests, etc. This would definitely be a super-power! Until recently, this super-power was at disposal only to rare ones who mastered the difficult skill of compiler development. Roslyn - C# and VB.NET Compiler-as-a-Service - gives this super-powers to every .NET developer.
+            <strong>
+                Du möchtest einen Vortrag halten oder eine Location zur Verfügung stellen? Melde dich einfach per E-Mail bei <a href="mailto:organizers@dotnetstammtisch.at">Gergö &amp; Christoph</a>.
+            </strong>
+            <!-- <li><a href="https://docs.google.com/presentation/d/1GVXNlJutGkuT_8ZxJs0XUU4PO1opBnmvN0vh75T83VQ">intro-page</a></li> -->
+        </div>        
 
-In the beginning of the talk we discuss compilers in general. How do they work? What makes them so complex to develop?
+        <!-- Upcoming Event -->
+        <div class="mb-3">
+            <h2>Nächster Termin</h2>
+            <i>Eine Anmeldung auf Meetup oder Facebook hilft uns die richtigen Mengen an Verpflegung bereitstellen zu können. Danke!</i>
+        </div>        
 
-Then we introduce Roslyn and discuss how and why it "changed the game" for .NET developers. We present few concrete projects built on top of Roslyn, and move toward examples of potential usage of Roslyn in our own projects. In particular, we discuss how to utilize Roslyn to increase code quality of our own projects.
-                </p>
-            </dd>
-            <dt>Talk 2</dt>
-            <dd>
-                <p><strong>Ralph Mayr: This is not your father's COBOL</strong> (<a href="https://onedrive.live.com/?authkey=%21AHIqPAyySlZ__-Y&cid=E7C65656BF61363B&id=E7C65656BF61363B%211779&parId=E7C65656BF61363B%211370&o=OneUp">Slides</a>, AddOn: <a href="https://onedrive.live.com/?authkey=%21ABrpaSDyj79Mez8&cid=E7C65656BF61363B&id=E7C65656BF61363B%211780&parId=E7C65656BF61363B%211370&o=OneUp">COBOL: From 0 to Hero</a>)</p>
-                <p>
-Despite being over 50 years old COBOL today is more relevant than ever before. It powers applications of the world's most crucial industries, including banking, healthcare and aviation. But as the software industry is changing rapidly, how can organizations bridge the ever-widening gap between their core business applications and the modern agile development world with its microservices, mobile devices and the Cloud?
-In this hands-on, live-coding session we're going to explore some answers to those questions. We'll start with the foundations of COBOL and Visual COBOL (the COBOL dialect that runs on the .NET CLR), and see how that fits in to a modern IT landscape.
-                </p>
-            </dd>
-            <dt>Talk 3</dt>
-            <dd>
-                <p><strong>Wilfried Mausz: Show me your face - and the machine tells you who you are</strong></p>
-                <p>Es hat einen Hauch von Science Fiction-Technologie, wenn ein Computer ein Gesicht erkennt, und alle möglichen 
-Merkmale wie Alter, Geschlecht, Emotionen, aber auch den Namen der Person ausgibt. 
-Solche Möglichkeiten, die bis vor kurzem nur von Technologiegiganten wie Apple und Google in ihren 
-Fotodiensten eingesetzt wurden, sind inzwischen für eigene Anwendungen nur mehr einen Servicecall entfernt. 
-In diesem Vortrag wird die Microsoft Face API vorgestellt und als Live-Demo eine Applikation gebaut, 
-                    die aus dem Video einer Webcam Gesichter lokalisiert und dann erkennt.</p>
-            </dd>
-            <dt>Community Links</dt>
-            <dd>
+        <div class="meeting active">
+            <h3>.NET Stammtisch #5</h3>
+            <dl class="dl-horizontal">
+                <dt>Datum</dt>
+                <dd>TBD</dd>
+
+                <dt>Location</dt>
+                <dd><a href="https://dataformers.at/">Dataformers</a></dd>
+            </dl>
+
+            <h5>Talks</h5>
+            <div class="d-flex">
+                <div class="talk-number">1</div>
+                <div>
+                    <p>TBA</p>
+                </div>
+            </div>
+
+            <div class="d-flex">
+                <div class="talk-number">2</div>
+                <div>
+                    <p>TBA</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Old Events -->
+        <h2 class="mb-3">Frühere Termine</h2>
+        
+        <!-- Stammtisch #4 -->
+        <div class="meeting">
+            <h3>.NET Stammtisch #4</h3>
+            <h6>(<a href="https://www.meetup.com/NET-Stammtisch-Linz/events/247045584/">Meetup</a>, <a href="https://www.facebook.com/events/868682779976980">Facebook</a>)</h6>
+
+            <dl class="dl-horizontal">
+                <dt>Datum</dt>
+                <dd>20.02.2018, 18:30</dd>
+
+                <dt>Location</dt>
+                <dd>
+                    <a href="https://factory300.spaces.nexudus.com/en/events/view//471680211/net-stammtisch-linz-4">Factory300</a> (Peter-Behrens-Platz 10, 4020 Linz)
+                    <!--
+                    <div class="alert alert-info">
+                        <p>Die Veranstaltung ist natürlich wie immer kostenlos. Der Veranstalter hat uns jedoch darum gebeten, trotzdem auf "Get tickets" beim verlinkten Event zu klicken. Vielen Dank!</p>
+                        <p>Folgenden Disclaimer müssen die TeilnehmerInnen akzeptieren:
+                            <br/>
+                            "Microsoft may use your email address to send you relevant content or offers. You can unsubscribe at any time. <a href="https://go.microsoft.com/fwlink/?LinkId=521839">Microsoft Privacy Statement</a>"
+                        <br/> 
+                            *Falls jemand damit ein Problem hat, bitte einfach bei uns melden!</p>
+                    </div>
+                    -->                
+                </dd>
+
+                <dt>Sponsoring</dt>
+                <dd>
+                    Dieses Mal sponsern <strong>Microsoft</strong> und <strong><a href="https://www.timecockpit.com/">Time Cockpit</a></strong> die Verpflegung.
+                </dd>                
+            </dl>
+
+            <h5>Talks</h5>
+            <div class="d-flex">
+                <div class="talk-number">1</div>
+                <div>
+                    <p><strong>Igor Rončević: Super-powers and the Compiler</strong></p>
+                    <p>
+                        Try to imagine how powerful would it be if programmers could look at their code through the eyes of their compilers. If they could automatically analyze their code, improve it, change it, cover it with tests, etc. This would definitely be a super-power! Until recently, this super-power was at disposal only to rare ones who mastered the difficult skill of compiler development. Roslyn - C# and VB.NET Compiler-as-a-Service - gives this super-powers to every .NET developer.
+                        In the beginning of the talk we discuss compilers in general. How do they work? What makes them so complex to develop?
+                        Then we introduce Roslyn and discuss how and why it "changed the game" for .NET developers. We present few concrete projects built on top of Roslyn, and move toward examples of potential usage of Roslyn in our own projects. In particular, we discuss how to utilize Roslyn to increase code quality of our own projects.
+                    </p>
+                </div>
+            </div>
+
+            <div class="d-flex">
+                <div class="talk-number">2</div>
+                <div>
+                    <p><strong>Ralph Mayr: This is not your father's COBOL</strong> (<a href="https://onedrive.live.com/?authkey=%21AHIqPAyySlZ__-Y&cid=E7C65656BF61363B&id=E7C65656BF61363B%211779&parId=E7C65656BF61363B%211370&o=OneUp">Slides</a>, AddOn: <a href="https://onedrive.live.com/?authkey=%21ABrpaSDyj79Mez8&cid=E7C65656BF61363B&id=E7C65656BF61363B%211780&parId=E7C65656BF61363B%211370&o=OneUp">COBOL: From 0 to Hero</a>)</p>
+                    <p>
+                        Despite being over 50 years old COBOL today is more relevant than ever before. It powers applications of the world's most crucial industries, including banking, healthcare and aviation. But as the software industry is changing rapidly, how can organizations bridge the ever-widening gap between their core business applications and the modern agile development world with its microservices, mobile devices and the Cloud?
+                        In this hands-on, live-coding session we're going to explore some answers to those questions. We'll start with the foundations of COBOL and Visual COBOL (the COBOL dialect that runs on the .NET CLR), and see how that fits in to a modern IT landscape.
+                    </p>
+                </div>
+            </div>
+
+                <div class="d-flex">
+                    <div class="talk-number">3</div>
+                    <div>
+                        <p><strong>Wilfried Mausz: Show me your face - and the machine tells you who you are</strong></p>
+                        <p>
+                            Es hat einen Hauch von Science Fiction-Technologie, wenn ein Computer ein Gesicht erkennt, und alle möglichen 
+                            Merkmale wie Alter, Geschlecht, Emotionen, aber auch den Namen der Person ausgibt. 
+                            Solche Möglichkeiten, die bis vor kurzem nur von Technologiegiganten wie Apple und Google in ihren 
+                            Fotodiensten eingesetzt wurden, sind inzwischen für eigene Anwendungen nur mehr einen Servicecall entfernt. 
+                            In diesem Vortrag wird die Microsoft Face API vorgestellt und als Live-Demo eine Applikation gebaut, 
+                            die aus dem Video einer Webcam Gesichter lokalisiert und dann erkennt.
+                        </p>
+                    </div>
+            </div>
+                
+            <div>
+                <h5>Community Links</h5>
                 <ul>
-
                     <li><strong><a href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-2">C# 7.2 release</strong></a> (in, ref readonly, readonly struct, ref struct, private protected)</li>
                     <li><strong><a href="https://blogs.msdn.microsoft.com/webdev/2017/11/09/creating-a-minimal-asp-net-core-windows-container/">Reduze ASP.NET Core Docker image size from 1.24GB to 357MB</a></strong></li>
                     <li><strong><a href="https://www.hanselman.com/blog/TryingOutNewNETCoreAlpineDockerImages.aspx">ASP.NET Core 2.1 for docker alpine (83MB)</a></strong></li>
@@ -115,91 +168,118 @@ In diesem Vortrag wird die Microsoft Face API vorgestellt und als Live-Demo eine
                     <li><strong><a href="http://www.techconference.at/">Microsoft Tech Conference 2018</strong></a></li>
                     <li><strong><a href="http://global.azurebootcamp.net/locations/austria-linz/">Global Azure Bootcamp 2018</strong></a></li>
                     <li><strong><a href="https://devone.at/">DevOne Linz 2018</strong></a></li>
-
                 </ul>
-            </dd>
-        </dl>
+            </div>
+        </div>
         
+        <!-- Stammtisch #3 -->
+        <div class="meeting">
+            <h3>.NET Stammtisch #3</h3>
+            <h6>(<a href="https://www.meetup.com/NET-Stammtisch-Linz/events/243674915/">Meetup</a>, <a href="https://www.facebook.com/events/1658423457542239">Facebook</a>)</h6>
 
-        <h3>.NET Stammtisch #3 (<a href="https://www.meetup.com/NET-Stammtisch-Linz/events/243674915/">Meetup</a>, <a href="https://www.facebook.com/events/1658423457542239">Facebook</a>)</h3>
-        <dl class="dl-horizontal">
-            <dt>Datum</dt><dd>24.10.2017, 18:30</dd>
-            <dt>Location</dt>
-            <dd>
-                <a href="https://www.bet-at-home.com/">bet-at-home Linz</a> (Hafenstraße 47-51, 4020 Linz)
-                
-                <!--<div class="alert alert-info">
-                    <p>Die Veranstaltung findet im <strong>TechCenter Seminarbereich (Bauteil C)</strong> statt. Der Seminarbereich befindet sich beim Schranken der Zufahrt rechts. Der Eingang des Seminarbereichs liegt direkt an der Hafenstr.</p>
-                    <p><strong>Bus:</strong> ab Taubenmarkt, Linie 27 (Richtung: Linz/Donau Fernheizkraftwerk), Haltestelle Gallanderstraße</p>
-                    </p>
-                    <p>
-                        <strong>Parken:</strong>
-                        <ul>
-                            <li>Kostenpflichtig in der TG des TechCenters.</li>
-                            <li>Kurzparkzone entlang der Hafenstr. bis 18:30.</li>
-                            <li>Parken ohne Kurzparkzone in Schiffbaustr. bzw. Sintstr.</li>
-                        </ul>
-                    </p>
-                </div>-->
-            </dd>
-            <dt>Talk 1</dt>
-            <dd>
-                <p><strong>Dominik Krenner: The .NET Profiling API</strong> (<a href="slides/003/The-Profiling-API.pdf">Slides</a>) </p>
-                <p>In diesem Vortrag wird die .NET Profiling API vorgestellt die seit .NET 1.0 existiert. Nach einem kurzen Überblick über die API  wird in einer Live-Demo gezeigt, wie Methoden Aufrufe überwacht werden können und wie mithilfe des ReJIT-Features Anwendungscode zur Laufzeit verändert werden kann.</p>
-            </dd>
-            <dt>Talk 2</dt>
-            <dd>
-                <p><strong>David Daxbacher: Azure Machine Learning</strong> (<a href="slides/003/Praesentation-AzureMLStudio.pdf">Slides</a>) </p>
-                <p>In diesem Vortrag wird das Azure Machine Learning Studio von Microsoft anhand von praktischen Erfahrungen näher erläutert. 
-Dazu wird in einer Live-Demo das Anlegen eines Trainings Experiments, anschließendes Erstellen eines Vorhersagemodells und das Veröffentlichen des finalen Experiments als Web Service Schritt für Schritt präsentiert. 
-Bei dem vorgezeigten Experiment handelt es sich nicht um ein fiktives Beispiel sondern um eines für Bet-At-Home erstellten Experiments, das später in der Praxis Anwendung finden soll.</p>
-            </dd>
-            <dt>Community Links</dt>
-            <dd>
+            <dl class="dl-horizontal">
+                    <dt>Datum</dt><dd>24.10.2017, 18:30</dd>
+                    <dt>Location</dt>
+                    <dd>
+                        <a href="https://www.bet-at-home.com/">bet-at-home Linz</a> (Hafenstraße 47-51, 4020 Linz)
+                        
+                        <!--<div class="alert alert-info">
+                            <p>Die Veranstaltung findet im <strong>TechCenter Seminarbereich (Bauteil C)</strong> statt. Der Seminarbereich befindet sich beim Schranken der Zufahrt rechts. Der Eingang des Seminarbereichs liegt direkt an der Hafenstr.</p>
+                            <p><strong>Bus:</strong> ab Taubenmarkt, Linie 27 (Richtung: Linz/Donau Fernheizkraftwerk), Haltestelle Gallanderstraße</p>
+                            </p>
+                            <p>
+                                <strong>Parken:</strong>
+                                <ul>
+                                    <li>Kostenpflichtig in der TG des TechCenters.</li>
+                                    <li>Kurzparkzone entlang der Hafenstr. bis 18:30.</li>
+                                    <li>Parken ohne Kurzparkzone in Schiffbaustr. bzw. Sintstr.</li>
+                                </ul>
+                            </p>
+                        </div>-->
+                    </dd>
+            </dl>
+
+            <div>
+                <h5>Talks</h5>
+                <div class="d-flex">
+                    <div class="talk-number">1</div>
+                    <div>
+                        <p><strong>Dominik Krenner: The .NET Profiling API</strong> (<a href="slides/003/The-Profiling-API.pdf">Slides</a>)</p>
+                        <p>
+                            In diesem Vortrag wird die .NET Profiling API vorgestellt die seit .NET 1.0 existiert. Nach einem kurzen Überblick über die API  wird in einer Live-Demo gezeigt, wie Methoden Aufrufe überwacht werden können und wie mithilfe des ReJIT-Features Anwendungscode zur Laufzeit verändert werden kann.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="d-flex">
+                    <div class="talk-number">2</div>
+                    <div>
+                        <p><strong>David Daxbacher: Azure Machine Learning</strong> (<a href="slides/003/Praesentation-AzureMLStudio.pdf">Slides</a>)</p>
+                        <p>
+                            In diesem Vortrag wird das Azure Machine Learning Studio von Microsoft anhand von praktischen Erfahrungen näher erläutert. 
+                            Dazu wird in einer Live-Demo das Anlegen eines Trainings Experiments, anschließendes Erstellen eines Vorhersagemodells und das Veröffentlichen des finalen Experiments als Web Service Schritt für Schritt präsentiert. 
+                            Bei dem vorgezeigten Experiment handelt es sich nicht um ein fiktives Beispiel sondern um eines für Bet-At-Home erstellten Experiments, das später in der Praxis Anwendung finden soll.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div>
+                <h5>Community Links</h5>
                 <ul>
-                    <li><strong>ASP.NET Community standup</strong> <a href="https://live.asp.net/">https://live.asp.net/</a> </li>
-                    <li><strong>NDC Videos</strong> <a href="https://www.youtube.com/channel/UCTdw38Cw6jcm0atBPA39a0Q/videos">https://www.youtube.com/channel/UCTdw38Cw6jcm0atBPA39a0Q/videos</a> </li>
-                    <li><strong>dnSpy</strong> <a href="https://github.com/0xd4d/dnSpy">https://github.com/0xd4d/dnSpy</a> </li>
-                    <li><strong>Pdocast: High Performance .NET with Ben Watson (Bing)</strong> <a href="http://6figuredev.com/podcast/episode-007-high-performance-net-with-ben-watson/">http://6figuredev.com/podcast/episode-007-high-performance-net-with-ben-watson/</a></li>
-                    <li><strong>.NET Conf 2017</strong> <a href="https://channel9.msdn.com/Events/dotnetConf/2017">https://channel9.msdn.com/Events/dotnetConf/2017</a> </li>
-                    <li><strong>Peachpie (PHP .NET)</strong> <a href="https://github.com/peachpiecompiler/peachpie">https://github.com/peachpiecompiler/peachpie</a> (<a href="https://channel9.msdn.com/Events/dotnetConf/2017/T213">.NET Conf Talk</a>)</li>
-                    <li><strong>Nodejs .NET</strong> <a href="https://github.com/tjanczuk/edge">https://github.com/tjanczuk/edge</a></li>
-                    <li><strong>SignalR for .NET Core Alpha</strong> <a href="https://blogs.msdn.microsoft.com/webdev/2017/09/14/announcing-signalr-for-asp-net-core-2-0/">https://blogs.msdn.microsoft.com/webdev/2017/09/14/announcing-signalr-for-asp-net-core-2-0/</a></li>
-                    <li><strong>Codetrack (Profiling tool)</strong> <a href="http://www.getcodetrack.com/">http://www.getcodetrack.com</a></li>
+                    <li><strong><a href="https://live.asp.net/">ASP.NET Community standup</a></strong></li>
+                    <li><strong><a href="https://www.youtube.com/channel/UCTdw38Cw6jcm0atBPA39a0Q/videos">NDC Videos</a></strong></li>
+                    <li><strong><a href="https://github.com/0xd4d/dnSpy">dnSpy</a></strong></li>
+                    <li><strong><a href="http://6figuredev.com/podcast/episode-007-high-performance-net-with-ben-watson/">Pdocast: High Performance .NET with Ben Watson (Bing)</a></strong></li>
+                    <li><strong><a href="https://channel9.msdn.com/Events/dotnetConf/2017">.NET Conf 2017</a></strong></li>
+                    <li><strong><a href="https://github.com/peachpiecompiler/peachpie">Peachpie (PHP .NET)</a></strong> (<a href="https://channel9.msdn.com/Events/dotnetConf/2017/T213">.NET Conf Talk</a>)</li>
+                    <li><strong><a href="https://github.com/tjanczuk/edge">Nodejs .NET</a></strong></li>
+                    <li><strong><a href="https://blogs.msdn.microsoft.com/webdev/2017/09/14/announcing-signalr-for-asp-net-core-2-0/">SignalR for .NET Core Alpha</a></strong></li>
+                    <li><strong><a href="http://www.getcodetrack.com/">Codetrack (Profiling tool)</a></strong></li>
                     <li><strong>CoreCLR -GC</strong> <a href="http://tooslowexception.com/zero-garbage-collector-for-net-core/">Konrad Kokosa - Zero Garbage Collector for .NET Core</a> and 
                                                      <a href="https://www.microsoft.com/en-us/research/wp-content/uploads/2017/07/snowflake-extended.pdf">Microsoft Research - Project Snowflake: Non-blocking Safe Manual Memory Management in .NET</a></li>
-                    <li><strong>PurePerformance podcast - .NET Core and ASP.NET Core</strong> <a href="https://www.spreaker.com/user/pureperformance/44-101-series-net-core-and-asp-net-core">https://www.spreaker.com/user/pureperformance/44-101-series-net-core-and-asp-net-core</a></li>
-                    <li><strong>Connect() conf</strong> <a href="https://www.microsoft.com/en-us/connectevent/">https://www.microsoft.com/en-us/connectevent/</a></li>
-                    <li><strong>corefx API Review/.NET Design Reviews</strong> <a href="https://www.youtube.com/playlist?list=PLRAdsfhKI4OWIV9TuZ0QmmlQzz41o80j0">https://www.youtube.com/playlist?list=PLRAdsfhKI4OWIV9TuZ0QmmlQzz41o80j0</a></li>
+                    <li><strong><a href="https://www.spreaker.com/user/pureperformance/44-101-series-net-core-and-asp-net-core">PurePerformance podcast - .NET Core and ASP.NET Core</a></strong></li>
+                    <li><strong><a href="https://www.microsoft.com/en-us/connectevent/">Connect() conf</a></strong></li>
+                    <li><strong><a href="https://www.youtube.com/playlist?list=PLRAdsfhKI4OWIV9TuZ0QmmlQzz41o80j0">corefx API Review/.NET Design Reviews</a></strong></li>
                 </ul>
-            </dd>
-        </dl>
+            </div>
+        </div>
+
+        <!-- Stammtisch #2 -->
+        <div class="meeting">
+            <h3>.NET Stammtisch #2</h3>
+            <h6>(<a href="https://www.facebook.com/events/1003694579733452">Facebook</a>)</h6>
+
+            <dl class="dl-horizontal">
+                <dt>Datum</dt>
+                <dd>26.07.2017, 18:30</dd>
+
+                <dt>Location</dt> 
+                <dd><a href="http://www.coworkingcube.at/">Coworking Cube Pucking</a></dd>
+            </dl>
+
+            <h5>Talks</h5>
+            <strong>Bernhard Rübl: Geschichten über Tasks</strong> (<a href="https://github.com/bernhard-ruebl/AsyncSamples">Code</a>)<br>
+            <strong>Rainer Stropek: Dockerizing .NET Apps</strong> (<a href="http://www.software-architects.com/devblog/2017/07/26/dotnet-stammtisch-dockerizing-dotnet-apps">Video vom Vortrag</a>)
+        </div>
         
-        <h3>.NET Stammtisch #2 (<a href="https://www.facebook.com/events/1003694579733452">Facebook</a>)</h3>
-        <dl class="dl-horizontal">
-            <dt>Datum</dt> <dd>26.07.2017, 18:30</dd>
-            <dt>Location</dt> <dd><a href="http://www.coworkingcube.at/">Coworking Cube Pucking</a></dd>
-            <dt>Talk 1</dt> <dd><strong>Bernhard Rübl: Geschichten über Tasks</strong> (<a href="https://github.com/bernhard-ruebl/AsyncSamples">Code</a>)</dd>
-            <dt>Talk 2</dt> <dd><strong>Rainer Stropek: Dockerizing .NET Apps</strong> (<a href="http://www.software-architects.com/devblog/2017/07/26/dotnet-stammtisch-dockerizing-dotnet-apps">Video vom Vortrag</a>)</dd>
-        </dl>
+        <!-- Stammtisch #1 -->
+        <div class="meeting">
+            <h3>.NET Stammtisch #1</h3>
+            <h6>(<a href="https://www.facebook.com/events/103865070169125">Facebook</a>)</h6>
 
-        <h3>.NET Stammtisch #1 (<a href="https://www.facebook.com/events/103865070169125">Facebook</a>)</h3>
-        <dl class="dl-horizontal">
-            <dt>Datum</dt> <dd> 23.05.2017, 18:30</dd>
-            <dt>Location</dt> <dd> <a href="https://www.dynatrace.com/">Dynatrace</a></dd>
-            <dt>Talk 1</dt> <dd><strong>Christoph Neumüller: How we automated .NET Crash Dump Analysis</strong> (<a href="https://www.slideshare.net/ChristophNeumller/large-scale-crash-dump-analysis-with-superdump">Slides</a>)</dd>
-            <dt>Talk 2</dt> <dd><strong>Gergely Kalapos: Build 2017 Zusammenfassung</strong> (<a href="https://onedrive.live.com/view.aspx?resid=B905280D056D6229!88349&ithint=file%2cpptx&app=PowerPoint&authkey=!AODVrZCfwqmXO0E">Slides</a>)</dd>
-        </dl>
+            <dl class="dl-horizontal">
+                <dt>Datum</dt> 
+                <dd> 23.05.2017, 18:30</dd>
 
-        <h2>Links</h2>
-        <ul>
-            <li><a href="https://www.meetup.com/NET-Stammtisch-Linz/">https://www.meetup.com/NET-Stammtisch-Linz/</a></li>
-            <li><a href="https://www.facebook.com/groups/1487350314622729/">https://www.facebook.com/groups/1487350314622729/</a></li>
-            <li><a href="https://twitter.com/DotNetLinz">https://twitter.com/DotNetLinz</a></li>
-            <li><a href="https://github.com/dotnetstammtisch/dotnetstammtisch.github.io">github.com/dotnetstammtisch/dotnetstammtisch.github.io</a></li>
-            <li><a href="https://docs.google.com/presentation/d/1GVXNlJutGkuT_8ZxJs0XUU4PO1opBnmvN0vh75T83VQ">intro-page</a></li>
-            <li>Du möchtest einen Vortrag halten oder eine Location zur Verfügung stellen? Melde dich einfach per E-Mail bei <a href="mailto:organizers@dotnetstammtisch.at">Gergö &amp; Christoph</a>.</li>
-        </ul>
+                <dt>Location</dt> 
+                <dd> <a href="https://www.dynatrace.com/">Dynatrace</a></dd>
+            </dl>
+
+            <h5>Talks</h5>
+            <strong>Christoph Neumüller: How we automated .NET Crash Dump Analysis</strong> (<a href="https://www.slideshare.net/ChristophNeumller/large-scale-crash-dump-analysis-with-superdump">Slides</a>)<br>
+            <strong>Gergely Kalapos: Build 2017 Zusammenfassung</strong> (<a href="https://onedrive.live.com/view.aspx?resid=B905280D056D6229!88349&ithint=file%2cpptx&app=PowerPoint&authkey=!AODVrZCfwqmXO0E">Slides</a>)
+        </div>
     </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,21 @@
+body {
+    background-color: #f5f5f5;
+}
+
+.talk-number {
+    font-size: 40px;
+    line-height: 40px;
+    color: lightgrey;
+    padding: 0 10px;
+}
+
+.meeting {    
+    margin-bottom: 20px;
+    padding: 1rem;
+    background: white;
+    border-radius: 8px;
+}
+
+.meeting.active {
+    border: 2px solid blue;
+}


### PR DESCRIPTION
Kleine Änderungen, die die Seite leserlicher machen sollten:

* Links für Facebook Gruppe, Meetup, Github Repo ganz oben (statt ganz unten)
* Meetings visuell besser abgrenzen
* aktuelles Meeting mit extra Border
* Links aus Stammtisch #3 hinter die Texte gelegt

Screenshot:
![36568505-90fd29c6-182a-11e8-9e6e-52815c3927f9](https://user-images.githubusercontent.com/16874688/36604143-2869908c-18bd-11e8-90e2-7c46800c7528.png)
